### PR TITLE
DRCWBTE 6331 - dollar sign issue

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -531,7 +531,6 @@ CharCmds['|'] = P(Paren, function(_, _super) {
 });
 
 var TextBlock =
-CharCmds.$ =
 LatexCmds.text =
 LatexCmds.textnormal =
 LatexCmds.textrm =


### PR DESCRIPTION
Want users to be able to enter a $ as text and not invoke mathquill.
