### PR TITLE
Bug with newlines and auto symbols

### DIFF
--- a/src/math.js
+++ b/src/math.js
@@ -217,7 +217,8 @@ var MathCommand = P(MathElement, function(_, _super) {
     var currentPoint = this;
     
     // this is a complex item, not text: we have no buffer
-    if(this.textTemplate && this.textTemplate.length > 1) return null;
+    if((this.textTemplate && this.textTemplate.length > 1) ||
+       (this.textTemplate && this.textTemplate.length >= 1 && this.textTemplate[0].length > 1)) return null;
 
     buffer = this.textTemplate[0];
     // assemble backwards


### PR DESCRIPTION
We shouldn't examine latex newlines for things like cos/sin/tan/ln