### PR TITLE
WriteIn should use the right cursor when there is an `\editable` bloc…

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -984,6 +984,9 @@ LatexCmds.vector = P(MathCommand, function(_, _super) {
 LatexCmds.editable = P(RootMathCommand, function(_, _super) {
   _.init = function() {
     MathCommand.prototype.init.call(this, '\\editable');
+    LatexCmds.editable.staticEquation = true;
+    LatexCmds.editable.staticEquations = LatexCmds.editable.staticEquations || [];
+    LatexCmds.editable.staticEquations.push(this);
   };
 
   _.jQadd = function() {

--- a/src/publicapi.js
+++ b/src/publicapi.js
@@ -54,6 +54,9 @@ jQuery.fn.mathquill = function(cmd, latex) {
           block = blockId && MathElement[blockId],
           cursor = block && block.cursor;
 
+        if (LatexCmds.editable.staticEquation)
+          cursor = LatexCmds.editable.staticEquations[0].cursor;
+
         if (cursor)
           cursor.writeLatex(latex).parent.blur();
         if (cmd === 'writeIn') {


### PR DESCRIPTION
…k present