### PR TITLE
TDD-4422: Screenreader updates for some Mathquill functions

### DIFF
--- a/src/commands.js
+++ b/src/commands.js
@@ -103,7 +103,7 @@ LatexCmds.overline = LatexCmds.bar = bind(Style, '\\overline', 'span', 'class="n
 
 var SupSub = P(MathCommand, function(_, _super) {
   _.init = function(ctrlSeq, tag, text) {
-    _super.init.call(this, ctrlSeq, '<'+tag+' class="non-leaf">&0</'+tag+'>', [ text ]);
+    _super.init.call(this, ctrlSeq, '<'+tag+' aria-hidden="true" class="' + tag.trim()+'-base non-leaf">&0</'+tag+'>', [ text ]);
   };
   _.charCountBehavior = 'e';
   _.finalizeTree = function() {
@@ -220,8 +220,8 @@ LatexCmds.fraction = P(MathCommand, function(_, _super) {
   _.ctrlSeq = '\\frac';
   _.htmlTemplate =
       '<span class="fraction non-leaf">'
-    +   '<span class="numerator">&0</span>'
-    +   '<span class="denominator">&1</span>'
+    +   '<span class="numerator" aria-hidden="true">&0</span>'
+    +   '<span class="denominator" aria-hidden="true">&1</span>'
     +   '<span style="display:inline-block;width:0">&nbsp;</span>'
     + '</span>'
   ;
@@ -323,9 +323,9 @@ LatexCmds.sqrt =
 LatexCmds['√'] = P(MathCommand, function(_, _super) {
   _.ctrlSeq = '\\sqrt';
   _.htmlTemplate =
-      '<span class="non-leaf">'
-    +   '<span class="scaled sqrt-prefix">&radic;</span>'
-    +   '<span class="non-leaf sqrt-stem">&0</span>'
+    '<span class="sqrt-base non-leaf">'
+    +   '<span class="scaled sqrt-prefix" aria-hidden="true">&radic;</span>'
+    +   '<span class="non-leaf sqrt-stem" aria-hidden="true">&0</span>'
     + '</span>'
   ;
   _.textTemplate = ['sqrt(', ')'];
@@ -450,7 +450,7 @@ LatexCmds.overleftrightarrow = P(HatCommand, function(_, _super) {
 var Bracket = P(MathCommand, function(_, _super) {
   _.init = function(open, close, ctrlSeq, end) {
     _super.init.call(this, '\\left'+ctrlSeq,
-        '<span class="non-leaf">'
+      '<span class="mathquill-bracket non-leaf" aria-hidden="true">'
       +   '<span class="scaled paren">'+open+'</span>'
       +   '<span class="non-leaf">&0</span>'
       +   '<span class="scaled paren">'+close+'</span>'

--- a/src/cursor.js
+++ b/src/cursor.js
@@ -13,8 +13,7 @@ JS environment could actually contain many instances. */
 var Cursor = P(Point, function(_) {
   _.init = function(root) {
     this.parent = this.root = root;
-    var jQ = this.jQ = this._jQ = $('<span class="cursor">&zwj;</span>');
-
+    var jQ = this.jQ = this._jQ = $('<span aria-hidden="true" class="cursor">&zwj;</span>');
     //closured for setInterval
     this.blink = function(){ jQ.toggleClass('blink'); };
 
@@ -362,6 +361,24 @@ var Cursor = P(Point, function(_) {
 
     if (this.deleteSelection()); // pass
     else if (this[dir]) {
+      const ariaMathAltTags = [
+        // manually entered from the the 'alt' key for each btn config containing an 'ariaTemplate' in eqb_toolbar_buttons_data
+        'Fraction',
+        'Square Root',
+        'Parentheses',
+        'Superscript',
+        'Triangle',
+        'Is Approximately Equal To',
+        'Is Perpendicular To',
+      ].map(alt => alt.replace(/ /g, ''));
+
+      const srOnlyClassId = this[dir].jQ.get(0).className.split(/\s+/).find(classname =>
+        ariaMathAltTags.some(alt =>
+          classname.includes(alt) && classname.length > alt.length
+        )
+      );
+      srOnlyClassId && jQuery(`.${srOnlyClassId}`).remove();
+
       if (this[dir].isEmpty())
         this[dir] = this[dir].remove()[dir];
       else

--- a/src/math.js
+++ b/src/math.js
@@ -409,14 +409,14 @@ var MathCommand = P(MathElement, function(_, _super) {
   };
   _.textTemplate = [''];
   _.text = function() {
-    var i = 0;
-    return this.foldChildren(this.textTemplate[i], function(text, child) {
+    var cmd = this, i = 0;
+    return cmd.foldChildren(cmd.textTemplate[i], function(text, child) {
       i += 1;
       var child_text = child.text();
-      if (text && this.textTemplate[i] === '('
-          && child_text[0] === '(' && child_text.slice(-1) === ')')
-        return text + child_text.slice(1, -1) + this.textTemplate[i];
-      return text + child.text() + (this.textTemplate[i] || '');
+      if (text && cmd.textTemplate[i] === '('
+        && child_text[0] === '(' && child_text.slice(-1) === ')')
+        return text + child_text.slice(1, -1) + cmd.textTemplate[i];
+      return text + child.text() + (cmd.textTemplate[i] || '');
     });
   };
 });

--- a/src/math.js
+++ b/src/math.js
@@ -409,14 +409,14 @@ var MathCommand = P(MathElement, function(_, _super) {
   };
   _.textTemplate = [''];
   _.text = function() {
-    var cmd = this, i = 0;
-    return cmd.foldChildren(cmd.textTemplate[i], function(text, child) {
+    var i = 0;
+    return this.foldChildren(this.textTemplate[i], function(text, child) {
       i += 1;
       var child_text = child.text();
-      if (text && cmd.textTemplate[i] === '('
-        && child_text[0] === '(' && child_text.slice(-1) === ')')
-        return text + child_text.slice(1, -1) + cmd.textTemplate[i];
-      return text + child.text() + (cmd.textTemplate[i] || '');
+      if (text && this.textTemplate[i] === '('
+          && child_text[0] === '(' && child_text.slice(-1) === ')')
+        return text + child_text.slice(1, -1) + this.textTemplate[i];
+      return text + child.text() + (this.textTemplate[i] || '');
     });
   };
 });

--- a/src/symbols.js
+++ b/src/symbols.js
@@ -29,7 +29,8 @@ var Variable = P(Symbol, function(_, _super) {
 
 var VanillaSymbol = P(Symbol, function(_, _super) {
   _.init = function(ch, html) {
-    _super.init.call(this, ch, '<span class="mq-vs-' + cssify(ch) + '">'+(html || ch)+'</span>');
+    var base = ch.length > 1 ? ch.slice(1) : ch;
+    _super.init.call(this, ch, '<span class="' + base.trim()+'-base mq-vs-' + cssify(ch) + '">'+(html || ch)+'</span>');
   };
 });
 
@@ -195,7 +196,7 @@ LatexCmds['¾'] = bind(LatexFragment, '\\frac34');
 var BinaryOperator = P(Symbol, function(_, _super) {
   _.init = function(ctrlSeq, html, text) {
     _super.init.call(this,
-      ctrlSeq, '<span class="binary-operator">'+html+'</span>', text
+      ctrlSeq, '<span class="' + ctrlSeq.slice(1).trim()+'-base binary-operator">'+html+'</span>', text
     );
   };
 });


### PR DESCRIPTION
https://datarecognitioncorp.atlassian.net/browse/TDD-4422

Related to: https://github.com/drc-devs/drc-ots/pull/8018

- `ariaMathAltTags` is manually updated here from the `alt` key of eqb_toolbar_button_data in drc-ots. This provides a way for mathquill to target the screenreader element generated for the math functions affected in this PR, so that it can remove that element when the host element is deleted. (ie when a Fraction elem is removed, the corresponding sr-only element for that will also be removed)