### PR TITLE
TDD-4422 - Node Lib Dec 2012

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,10 @@
     "pjs": "3.x"
   },
   "devDependencies": {
-    "mocha": "*",
+    "mocha": "1.7.4",
     "uglify-js": "2.4.13",
-    "less": "git://github.com/cloudhead/less.js",
-    "supervisor": "*",
-    "connect": "*"
+    "less": "1.3.3",
+    "supervisor": "0.5.0",
+    "connect": "2.7.1"
   }
 }


### PR DESCRIPTION
 * Fixes issue where "*" was being used for version references.
 * This repo was forked December 2012 (0.9.1)