### PR TITLE
TDD-5273 filter macOS option key initiation of accented alphabetic chars

### DIFF
--- a/src/textarea.js
+++ b/src/textarea.js
@@ -145,6 +145,7 @@ var manageTextarea = (function() {
 
     function popText(callback) {
       var text = textarea.val();
+      text = text.replace(/[ˆ´˜¨]/g, '');
       textarea.val('');
       if (text) callback(text);
     }


### PR DESCRIPTION
Filter out tilde, caret, umlaut, and accent specifically for macOS.
If typed using standard normal keys, these characters are blocked already by the WBTE allowedChars logic in eqb_view.
However, on macOS, the Option key can be used as a shortcut to an accented character, and then user would press the alphabetic letter to be accented to finish the keystroke.
Option + e = ´ (can follow with a, e, i, u to create á, é, í, ú)
Option + u - ¨ (can follow with a, e, i, o, u to create ä, ë, ï, ö, ü)
Option + i - ˆ (can follow with a, e, i, o, u to create â, ê, î, ô, û)
Option + n - ˜ (can follow with a, n, o to create ã, ñ, õ)

Attempting to intercept keydown, keyup and keypress events in WBTE doesn't work because it is too late, as mathquill has already written a div containing the accent character (even though the character itself would otherwise fail the allowed char filtering).