### PR TITLE
TDD-5273 disallow outcome chars from macos option key shortcut for accented chars

### DIFF
--- a/src/textarea.js
+++ b/src/textarea.js
@@ -145,7 +145,7 @@ var manageTextarea = (function() {
 
     function popText(callback) {
       var text = textarea.val();
-      text = text.replace(/[ˆ´˜¨]/g, '');
+      text = text.replace(/[ˆ´˜¨áéíúäëïöüâêîôûãñõ]/g, '');
       textarea.val('');
       if (text) callback(text);
     }


### PR DESCRIPTION
It turns out that while the previous TDD-5273 Pull Request did block accent characters from macOS option key shortcut for accented letters on their own to be blocked, the resulting accented letter itself can still be entered (press option+n, which results in a tilde accent that is blocked, but follow it with the letter 'n' itself, and ñ gets through). So adding accented letters as disallowed characters as well.