### PR TITLE
TDD-5249 Fix identifying iPad by using maxTouchPoints

### DIFF
--- a/src/rootelements.js
+++ b/src/rootelements.js
@@ -63,7 +63,7 @@ function createRoot(jQ, root, textbox, editable) {
 
   var iOS = false, android = false,
     p = navigator.platform;
-  if (p === 'iPad' || p === 'iPhone' || p === 'iPod'  || (navigator.userAgent.includes("Mac") && navigator.maxTouchPoints > 0)) {
+  if (p === 'iPad' || p === 'iPhone' || p === 'iPod' || ((navigator.userAgent.includes("iPad") || navigator.userAgent.includes("Macintosh")) && navigator.maxTouchPoints > 2)) {
     iOS = true;
   }
   if (p === 'Android') {

--- a/src/rootelements.js
+++ b/src/rootelements.js
@@ -63,7 +63,7 @@ function createRoot(jQ, root, textbox, editable) {
 
   var iOS = false, android = false,
     p = navigator.platform;
-  if (p === 'iPad' || p === 'iPhone' || p === 'iPod') {
+  if (p === 'iPad' || p === 'iPhone' || p === 'iPod'  || (navigator.userAgent.includes("Mac") && navigator.maxTouchPoints > 0)) {
     iOS = true;
   }
   if (p === 'Android') {


### PR DESCRIPTION
- Apple has be continuously changing `userAgent` string which is causing specific functionality applied for iPad to not work. 
- Fixed `iOS` by looking at `platform` as well as combination of `userAgent` and `maxTouchPoints`